### PR TITLE
WebSearch: new Add-to-Search Interface

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -688,6 +688,18 @@ CFG_WEBSEARCH_CITESUMMARY_SCAN_THRESHOLD = 20000
 ## CollectionNameSearchService search services to be enabled.
 CFG_WEBSEARCH_COLLECTION_NAMES_SEARCH = 0
 
+## CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES -- a dictionary containing
+## all the enabled search interfaces and their codes
+CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES = {
+    'simple': 0,
+    'advanced': 1,
+    'add-to-search': 2
+    }
+
+## CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE -- the code for the default
+## search interface based on CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES
+CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE = 0
+
 
 #######################################
 ## Part 4: BibHarvest OAI parameters ##

--- a/modules/miscutil/lib/inveniocfg.py
+++ b/modules/miscutil/lib/inveniocfg.py
@@ -225,7 +225,6 @@ You may want to customise your invenio-local.conf configuration accordingly."""
                        'CFG_BIBUPLOAD_FFT_ALLOWED_LOCAL_PATHS',
                        'CFG_BIBUPLOAD_CONTROLLED_PROVENANCE_TAGS',
                        'CFG_BIBUPLOAD_DELETE_FORMATS',
-                       'CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES',
                        'CFG_WEBSTYLE_HTTP_STATUS_ALERT_LIST',
                        'CFG_WEBSEARCH_RSS_I18N_COLLECTIONS',
                        'CFG_BATCHUPLOADER_FILENAME_MATCHING_POLICY',
@@ -248,12 +247,8 @@ You may want to customise your invenio-local.conf configuration accordingly."""
         for elem in option_value[1:-1].split(","):
             if elem:
                 elem = elem.strip()
-                if option_name in ['CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES']:
-                    # 3d1) integer values
-                    out += "%i, " % int(elem)
-                else:
-                    # 3d2) string values
-                    out += "'%s', " % elem
+                # string values
+                out += "'%s', " % elem
         out += "]"
         option_value = out
 
@@ -278,6 +273,11 @@ You may want to customise your invenio-local.conf configuration accordingly."""
     ## 3h) special cases: bibmatch validation list
     if option_name in ['CFG_BIBMATCH_MATCH_VALIDATION_RULESETS']:
         option_value = option_value[1:-1]
+
+    ## 3i) special cases: transform dictionary in list of values (integers)
+    if option_name in ['CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES']:
+        option_values = option_value[2:-2].split(',')
+        option_value = [int(value[value.index(':')+1:].strip()) for value in option_values]
 
     ## 4a) dropped variables
     if option_name in ['CFG_BATCHUPLOADER_WEB_ROBOT_AGENT']:
@@ -375,11 +375,6 @@ def cli_cmd_update_config_py(conf):
                 line_out = convert_conf_option(option, conf.get(section, option))
                 if line_out:
                     fdesc.write(line_out + "\n")
-    ## FIXME: special treatment for experimental variables
-    ## CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES and CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE
-    ## (not offering them in invenio.conf since they will be refactored)
-    fdesc.write("CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE = 0\n")
-    fdesc.write("CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES = [0, 1,]\n")
     ## generate postamble:
     fdesc.write("")
     fdesc.write("# END OF GENERATED FILE")

--- a/modules/websearch/lib/websearch_regression_tests.py
+++ b/modules/websearch/lib/websearch_regression_tests.py
@@ -250,11 +250,14 @@ class WebSearchTestLegacyURLs(InvenioTestCase):
 
         # Drop unnecessary arguments, like ln and as (when they are
         # the default value)
-        args = {'as': 0}
+        from invenio.config import CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE, \
+                CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES
+        args = {'as': CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE}
         check(make_url('/', c='Poetry', **args),
               make_url('/collection/Poetry', ln=CFG_SITE_LANG))
 
         # Otherwise, keep them
+        as_arg = [as_arg for as_arg in CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES if as_arg != CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE][0]
         args = {'as': 1, 'ln': CFG_SITE_LANG}
         check(make_url('/', c='Poetry', **args),
               make_url('/collection/Poetry', **args))
@@ -409,14 +412,16 @@ class WebSearchTestCollections(InvenioTestCase):
 
         browser = Browser()
 
+        from invenio.config import CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE, \
+                CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES
         try:
-            for aas in (0, 1):
+            for aas in CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES:
                 args = {'as': aas}
                 browser.open(make_url('/collection/Preprints', **args))
 
                 for jrec in (11, 21, 11, 27):
                     args = {'jrec': jrec, 'cc': 'Preprints'}
-                    if aas:
+                    if aas != CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE:
                         args['as'] = aas
 
                     url = make_rurl('/search', **args)
@@ -564,7 +569,8 @@ class WebSearchTestBrowse(InvenioTestCase):
         """ websearch - check that browsing works """
 
         browser = Browser()
-        browser.open(make_url('/', ln="en"))
+        args = {'as': 0, 'ln': 'en'}
+        browser.open(make_url('/', **args))
 
         browser.select_form(name='search')
         browser['f'] = ['title']
@@ -718,9 +724,10 @@ class WebSearchTestSearch(InvenioTestCase):
         """ websearch - check extension of a query to the home collection """
 
         browser = Browser()
+        args = {'ln':'en', 'as': 0}
 
         # We do a precise search in an isolated collection
-        browser.open(make_url('/collection/ISOLDE', ln='en'))
+        browser.open(make_url('/collection/ISOLDE', **args))
 
         browser.select_form(name='search')
         browser['f'] = ['author']
@@ -744,7 +751,8 @@ class WebSearchTestSearch(InvenioTestCase):
         """ websearch - provide a list of nearest terms """
 
         browser = Browser()
-        browser.open(make_url(''))
+        args = {'as': 0}
+        browser.open(make_url('', **args))
 
         # Search something weird
         browser.select_form(name='search')
@@ -801,32 +809,12 @@ class WebSearchTestSearch(InvenioTestCase):
                                  'f': ['title'],
                                  'ln': ['en']})
 
-    def test_switch_to_advanced_search(self):
-        """ websearch - switch to advanced search """
-
-        browser = Browser()
-        browser.open(make_url('/collection/ISOLDE'))
-
-        browser.select_form(name='search')
-        browser['p'] = 'tandem'
-        browser['f'] = ['title']
-        browser.submit()
-
-        browser.follow_link(text='Advanced Search')
-
-        dummy, q = parse_url(browser.geturl())
-
-        self.failUnlessEqual(q, {'cc': ['ISOLDE'],
-                                 'p1': ['tandem'],
-                                 'f1': ['title'],
-                                 'as': ['1'],
-                                 'ln' : ['en']})
-
     def test_no_boolean_hits(self):
         """ websearch - check the 'no boolean hits' proposed links """
 
         browser = Browser()
-        browser.open(make_url(''))
+        args = {'as': 0}
+        browser.open(make_url('', **args))
 
         browser.select_form(name='search')
         browser['p'] = 'quasinormal muon'
@@ -849,7 +837,8 @@ class WebSearchTestSearch(InvenioTestCase):
         """ websearch - test similar authors box """
 
         browser = Browser()
-        browser.open(make_url(''))
+        args = {'as': 0}
+        browser.open(make_url('', **args))
 
         browser.select_form(name='search')
         browser['p'] = 'Ellis, R K'

--- a/modules/websearch/lib/websearch_webcoll.py
+++ b/modules/websearch/lib/websearch_webcoll.py
@@ -721,12 +721,24 @@ class Collection:
 
     def create_searchfor(self, aas=CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE, ln=CFG_SITE_LANG):
         "Produces either Simple or Advanced 'Search for' box for the current collection."
-        if aas == 1:
+        if aas == 2:
+            return self.create_searchfor_addtosearch(ln)
+        elif aas == 1:
             return self.create_searchfor_advanced(ln)
         elif aas == 0:
             return self.create_searchfor_simple(ln)
         else:
             return self.create_searchfor_light(ln)
+
+    def create_searchfor_addtosearch(self, ln=CFG_SITE_LANG):
+        "Produces add-to-search 'Search for' box for the current collection."
+
+        return websearch_templates.tmpl_searchfor_addtosearch(
+          ln=ln,
+          collection_id=self.name,
+          record_count=self.nbrecs,
+          searchwithin= self.create_searchwithin_selection_box(fieldname='f1', ln=ln),
+        )
 
     def create_searchfor_light(self, ln=CFG_SITE_LANG):
         "Produces light 'Search for' box for the current collection."

--- a/modules/websearch/lib/websearch_webinterface.py
+++ b/modules/websearch/lib/websearch_webinterface.py
@@ -771,7 +771,7 @@ class WebInterfaceSearchInterfacePages(WebInterfaceDirectory):
         if argd.has_key('as'):
             argd['aas'] = argd['as']
             del argd['as']
-        if argd.get('aas', CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE) not in (0, 1):
+        if argd.get('aas', CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE) not in CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES:
             argd['aas'] = CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE
 
         # If we specify no collection, then we don't need to redirect

--- a/modules/webstyle/css/invenio.css
+++ b/modules/webstyle/css/invenio.css
@@ -575,7 +575,7 @@ a.footer:hover {
    color: #000;
    background: #fff;
    padding: 1px;
-   margin: 5px 0px 5px 0px;
+   /*margin: 5px 0px 5px 0px;*/
    border-collapse: collapse;
    /*border-top: 1px solid #36c;*/
 }
@@ -3295,6 +3295,29 @@ div.bibcircbottom {
     width: 50%;
 }
 
+
+/* add-to-search */
+
+#advbox{
+    padding-bottom: 20px;
+    white-space: nowrap;
+}
+
+a#advbox-toggle{
+    text-decoration: none;
+    color: #3366CC;
+}
+
+#advbox-toggle-button{
+    background-color: #DDDDDD;
+    border-radius: 3px 3px 3px 3px;
+    color: #3366CC;
+    font-weight: 400;
+    padding: 1px 6px;
+    text-decoration: none;
+}
+
+/*End - add-to-search*/
 
 /* Rollover menus */
 


### PR DESCRIPTION
- New search box interface that contains both simple search
  and advanced search (javascript dependent) (addresses #622).
- Replaces the 3-line advanced search, with only 1-line add-to-search,
  with the possibility of adding patterns to the current search pattern.
- Ammends regression tests to take into account a third search
  interface.
- Moves the config variables CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES and
  CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACES from the inveniocfg.py to
  invenio.config (closes #271)

Signed-off-by: Ludmila Marian ludmila.marian@gmail.com
